### PR TITLE
Develop (#29)

### DIFF
--- a/app/auth.py
+++ b/app/auth.py
@@ -26,6 +26,7 @@ class JWTBearer(HTTPBearer):
     def __init__(self, auto_error: bool = True):
         super().__init__(auto_error=auto_error)
         self._logger = Logger()
+        self.auto_error = auto_error
         self.cache_service = CacheService()
         self.settings = Settings()
 
@@ -33,19 +34,17 @@ class JWTBearer(HTTPBearer):
         credentials = await super(JWTBearer, self).__call__(request)
         if credentials:
             if not await self._validate_token(credentials.credentials):
-                self._logger.error(
-                    f'Invalid authentication token credentials={credentials}'
-                )
-                raise HTTPException(
-                    status_code=status.HTTP_403_FORBIDDEN,
-                    detail='Invalid authentication token',
-                )
+                if self.auto_error:
+                    self._logger.error(f'Invalid authentication token {credentials=}')
+                    raise HTTPException(
+                        status_code=status.HTTP_403_FORBIDDEN,
+                        detail='Not authenticated',
+                    )
+                else:
+                    return None
             return self.decoded_token
         else:
-            self._logger.error(f'Credentials missing during authentications')
-            raise HTTPException(
-                status_code=status.HTTP_403_FORBIDDEN, detail='Not authenticated'
-            )
+            return None
 
     @tracer.capture_method
     async def _validate_token(self, token: str) -> bool:

--- a/app/repository/post.py
+++ b/app/repository/post.py
@@ -3,7 +3,7 @@ from typing import List
 
 import boto3
 import pendulum
-from boto3.dynamodb.conditions import Key, Attr
+from boto3.dynamodb.conditions import Key, AttributeBase
 
 from app.exception import PostNotFoundException
 from app.models.post import Post
@@ -35,19 +35,20 @@ class PostRepository:
         self._table.put_item(Item=post.dict())
         return post
 
-    async def delete_post(self, post_uuid: str):
-        post = await self.get_post_by_uuid(post_uuid)
-        post.deleted_at = pendulum.now().to_iso8601_string()
-        self._table.put_item(Item=post.dict())
+    async def delete_post(self, post_uuid: str, filter_expression: AttributeBase):
+        post = await self.get_post_by_uuid(post_uuid, filter_expression)
+        if post.deleted_at is None:
+            post.deleted_at = pendulum.now().to_iso8601_string()
+            self._table.put_item(Item=post.dict())
 
-    async def get_all_posts(self) -> List[Post]:
+    async def get_all_posts(self, filter_expression: AttributeBase) -> List[Post]:
         posts = []
-        response = self._table.scan(FilterExpression=Attr('deleted_at').eq(None))
+        response = self._table.scan(FilterExpression=filter_expression)
         items = response['Items']
         while 'LastEvaluatedKey' in response:
             response = self._table.scan(
                 ExclusiveStartKey=response['LastEvaluatedKey'],
-                FilterExpression=Attr('deleted_at').eq(None),
+                FilterExpression=filter_expression,
             )
             items.extend(response['Items'])
 
@@ -55,17 +56,23 @@ class PostRepository:
             posts.append(Post.parse_obj(item))
         return posts
 
-    async def get_post_by_uuid(self, post_uuid: str) -> Post:
+    async def get_post_by_uuid(
+        self,
+        post_uuid: str,
+        filter_expression: AttributeBase,
+    ) -> Post:
         response = self._table.query(
             KeyConditionExpression=Key('id').eq(post_uuid),
-            FilterExpression=Attr('deleted_at').eq(None),
+            FilterExpression=filter_expression,
         )
-        if response['Count'] != 0:
+        if response['Count'] == 1:
             return Post.parse_obj(response['Items'][0])
         raise PostNotFoundException(f'Post was not found with UUID {post_uuid=}')
 
-    async def update_post(self, post_uuid: str, data: dict):
-        post = await self.get_post_by_uuid(post_uuid)
+    async def update_post(
+        self, post_uuid: str, data: dict, filter_expression: AttributeBase
+    ):
+        post = await self.get_post_by_uuid(post_uuid, filter_expression)
         post = post.copy(update=data)
         post.updated_at = pendulum.now().to_iso8601_string()
         self._table.put_item(Item=post.dict())

--- a/app/schemas/post.py
+++ b/app/schemas/post.py
@@ -14,6 +14,9 @@ class CreatePost(CamelModel):
     meta: Optional[Meta]
     published_at: Optional[str]
 
+    class Config:
+        validation = False
+
 
 class UpdatePost(CreatePost):
     pass

--- a/app/services/post.py
+++ b/app/services/post.py
@@ -2,11 +2,11 @@ import uuid
 from typing import List
 
 from aws_lambda_powertools import Logger, Tracer
+from boto3.dynamodb.conditions import Attr
 from slugify import slugify
 
 from app.models.post import Post
 from app.repository.post import PostRepository
-
 
 tracer = Tracer()
 
@@ -16,6 +16,8 @@ def create_slug(title: str, post_uuid: uuid.UUID) -> str:
 
 
 class PostService:
+    NOT_DELETED_FILTER = Attr('deleted_at').eq(None)
+
     def __init__(self):
         self._logger = Logger()
         self._repository = PostRepository()
@@ -27,17 +29,19 @@ class PostService:
 
     @tracer.capture_method
     async def delete_post(self, post_uuid: str):
-        await self._repository.delete_post(post_uuid)
+        await self._repository.delete_post(post_uuid, self.NOT_DELETED_FILTER)
         self._logger.info(f'Post successfully deleted {post_uuid=}')
 
     @tracer.capture_method
     async def get_all_posts(self) -> List[Post]:
-        return await self._repository.get_all_posts()
+        return await self._repository.get_all_posts(self.NOT_DELETED_FILTER)
 
     @tracer.capture_method
     async def get_post(self, post_uuid: str) -> Post:
-        return await self._repository.get_post_by_uuid(post_uuid)
+        return await self._repository.get_post_by_uuid(
+            post_uuid, self.NOT_DELETED_FILTER
+        )
 
     @tracer.capture_method
     async def update_post(self, post_uuid: str, data: dict):
-        await self._repository.update_post(post_uuid, data)
+        await self._repository.update_post(post_uuid, data, self.NOT_DELETED_FILTER)

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -2,6 +2,7 @@ import uuid
 
 import pendulum
 import pytest
+from boto3.dynamodb.conditions import AttributeBase, Attr
 
 from app.auth import JWTBearer, JWTToken
 from app.models.post import Post
@@ -17,6 +18,11 @@ def cache_service():
 @pytest.fixture
 def jwt_bearer() -> JWTBearer:
     return JWTBearer()
+
+
+@pytest.fixture
+def filter_expression() -> AttributeBase:
+    return Attr('deleted_at').eq(None)
 
 
 @pytest.fixture

--- a/tests/unit/service/test_post_service.py
+++ b/tests/unit/service/test_post_service.py
@@ -1,3 +1,5 @@
+from unittest.mock import ANY
+
 import pytest
 from starlette import status
 
@@ -43,7 +45,7 @@ class TestPostService:
     ):
         mocker.patch('app.repository.post.PostRepository.delete_post')
         await post_service.delete_post(post_model.id)
-        post_repository.delete_post.assert_called_once_with(post_model.id)
+        post_repository.delete_post.assert_called_once_with(post_model.id, ANY)
 
     async def test_fail_to_delete_post_by_uuid_due_post_not_found_exception(
         self,
@@ -66,7 +68,7 @@ class TestPostService:
             f'Post was not found with UUID post_uuid={post_model.id}'
             == excinfo.value.detail
         )
-        post_repository.get_post_by_uuid.assert_called_once_with(post_model.id)
+        post_repository.get_post_by_uuid.assert_called_once_with(post_model.id, ANY)
 
     async def test_successfully_get_all_posts(
         self,
@@ -82,7 +84,7 @@ class TestPostService:
         result = await post_service.get_all_posts()
         assert len(result) == 1
         assert post_model == result[0]
-        post_repository.get_all_posts.assert_called_once()
+        post_repository.get_all_posts.assert_called_once_with(ANY)
 
     async def test_successfully_get_post_by_uuid(
         self,
@@ -97,7 +99,7 @@ class TestPostService:
         )
         result = await post_service.get_post(post_model.id)
         assert post_model == result
-        post_repository.get_post_by_uuid.assert_called_once_with(post_model.id)
+        post_repository.get_post_by_uuid.assert_called_once_with(post_model.id, ANY)
 
     async def test_fail_to_get_post_by_uuid_due_post_not_found_exception(
         self,
@@ -120,7 +122,7 @@ class TestPostService:
             f'Post was not found with UUID post_uuid={post_model.id}'
             == excinfo.value.detail
         )
-        post_repository.get_post_by_uuid.assert_called_once_with(post_model.id)
+        post_repository.get_post_by_uuid.assert_called_once_with(post_model.id, ANY)
 
     async def test_successfully_update_post(
         self,
@@ -132,7 +134,7 @@ class TestPostService:
         mocker.patch('app.repository.post.PostRepository.update_post')
         data = {'content', 'Updated content'}
         await post_service.update_post(post_model.id, data)
-        post_repository.update_post.assert_called_once_with(post_model.id, data)
+        post_repository.update_post.assert_called_once_with(post_model.id, data, ANY)
 
     async def test_fail_to_update_post_due_post_not_found_exception(
         self,
@@ -156,4 +158,4 @@ class TestPostService:
             f'Post was not found with UUID post_uuid={post_model.id}'
             == excinfo.value.detail
         )
-        post_repository.get_post_by_uuid.assert_called_once_with(post_model.id)
+        post_repository.get_post_by_uuid.assert_called_once_with(post_model.id, ANY)

--- a/tests/unit/test_auth.py
+++ b/tests/unit/test_auth.py
@@ -7,7 +7,6 @@ from starlette import status
 
 from app.auth import JWTBearer, JWTToken
 
-INVALID_AUTHENTICATION_TOKEN = 'Invalid authentication token'
 NOT_AUTHENTICATED = 'Not authenticated'
 
 
@@ -54,8 +53,16 @@ class TestJWTAuth:
         empty_request.headers = {'Authorization': 'Bearer asdf'}
         with pytest.raises(HTTPException) as excinfo:
             await jwt_bearer(empty_request)
-        assert INVALID_AUTHENTICATION_TOKEN == excinfo.value.detail
+        assert NOT_AUTHENTICATED == excinfo.value.detail
         assert status.HTTP_403_FORBIDDEN == excinfo.value.status_code
+
+    async def test_fail_to_authorize_request_due_to_bearer_token_is_invalid_with_auto_error_false(
+        self, empty_request
+    ):
+        empty_request.headers = {'Authorization': 'Bearer asdf'}
+        jwt_bearer = JWTBearer(auto_error=False)
+        result = await jwt_bearer(empty_request)
+        assert result is None
 
     async def test_fail_to_authorize_request_due_to_bearer_token_is_missing(
         self, empty_request, jwt_bearer
@@ -72,18 +79,25 @@ class TestJWTAuth:
         mocker.patch('app.services.cache.CacheService.get', return_value=jwt_token.jti)
         with (pytest.raises(HTTPException)) as excinfo:
             await jwt_bearer(valid_request)
+        assert NOT_AUTHENTICATED == excinfo.value.detail
         assert status.HTTP_403_FORBIDDEN == excinfo.value.status_code
-        assert INVALID_AUTHENTICATION_TOKEN == excinfo.value.detail
         cache_service.get.assert_called_once_with(f'jti_{jwt_token.jti}')
 
     async def test_fail_to_authorize_request_due_to_missing_credentials(
         self, empty_request
     ):
-        jwt_bearer = JWTBearer(auto_error=False)
+        jwt_bearer = JWTBearer()
         with (pytest.raises(HTTPException)) as excinfo:
             await jwt_bearer(empty_request)
         assert status.HTTP_403_FORBIDDEN == excinfo.value.status_code
         assert NOT_AUTHENTICATED == excinfo.value.detail
+
+    async def test_fail_to_authorize_request_due_to_missing_credentials_with_auto_error_false(
+        self, empty_request
+    ):
+        jwt_bearer = JWTBearer(auto_error=False)
+        result = await jwt_bearer(empty_request)
+        assert result is None
 
     async def test_successfully_authorize_request(
         self, mocker, cache_service, jwt_bearer, jwt_token, valid_request


### PR DESCRIPTION
* Added aws-lambda-powertools

* Added powertools logger

* Format with black

* Updated Pipfile.lock

* Added certifi package

* Revert "Added certifi package"

This reverts commit 2b89981dccf4169b264b64603173945e5dab55bc.

* Disabled pipenv caching for debugging (from yesterday to today the workflow is broke by itself 🤷)

* There is no 'cache: false'

* Revert "There is no 'cache: false'"

This reverts commit 508432114d630c47104f1cc17b00d12d36d94900.

* Revert "Disabled pipenv caching for debugging (from yesterday to today the workflow is broke by itself 🤷)"

This reverts commit 206a91103e8928cacd465fe292ff3306efd3b068.

* Try ubuntu-22.04

* Revert "Try ubuntu-22.04"

This reverts commit 38b576b1a8bf05902fce873b5afa96d7c4777de2.

* List installed pipenv packages

* Display venv path after install

* Revert "Display venv path after install"

This reverts commit 9e097fbbc2836dcbc20c5c4e6c737980ea9dad97.

* Install certifi package with pipenv

* Revert "Install certifi package with pipenv"

This reverts commit 7ec0a5b523b6a3526f7df73d51769401dd8aba63.

* Added aws-lambda-powertools package

* Revert "Added aws-lambda-powertools package"

This reverts commit 8b5fc6c65b65e08a4927525c0b02626d0d7ee3da.

* Added aws-lambda-powertools package (1.26.7)

* Revert "Added aws-lambda-powertools package (1.26.7)"

This reverts commit a15a4a2140dba320e751e067da6623c40fa2761c.

* Added aws-lambda-powertools

* Added certifi

* Format with black

* Skip app tests until fix

* Revert "Skip app tests until fix"

This reverts commit 3ce90f9437736b99cb4ff605a09903b635d4b403.

* Removed pytest-httpx for testing

* Replaced pytest-httpx with respx

* Refactor

* Removed autopep8

* Refactor

* Reformat with black

* Refactor

* Added aws-lambda-powertools logger, metrics and tracer

* Replaced logging with aws-lambda-powertools logger

* Revert "Replaced logging with aws-lambda-powertools logger"

This reverts commit ed7d33de185b000cc3583dc4d491915864286bcc.

* Fixed typo

* Removed utils.py

* Replaced logging with aws_lambda_powertools logger

* Added post repository

* Refactor

* Added post repository tests

* Updated serverless-offline version from 8.8.0 to 9.2.4

* Removed serverless-offline related configuration

* Added faulty tests

* Added faulty tests

* Raise exception based on auto_error

* Refactor

* Simplified error details

* Added token to routes and request body validation set to manual

* Added filter expression as parameter